### PR TITLE
vscode-tilt: publishing instructions + rename extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,13 @@ The language server functionality is built into Tilt itself via the `tilt lsp` c
 [starlark-lsp]: https://github.com/tilt-dev/starlark-lsp
 
 The [`Tiltfile` in the starlark-lsp repository](/tilt-dev/starlark-lsp/blob/main/Tiltfile) is set up to run the language server and automatically recompile on changes. The VS Code extension has extra handling to detect when the language server stops or disconnects and automatically reconnects to it. If it fails to reconnect (for example, due to a compile error), use the "Restart Tiltfile LSP Server" command (mentioned above) to reconnect to your development language server.
+
+## Publishing the extension to the VSCode Marketplace
+
+The extension is published via `vsce publish`.
+Setup:
+1. Install vsce (per vs docs above) ([docs](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#installation).
+2. Get access to the tilt-dev VSCode Marketplace publisher
+  1. Log into VSCode Marketplace and get your user ID as described [here](https://docs.microsoft.com/en-us/visualstudio/extensibility/walkthrough-publishing-a-visual-studio-extension?view=vs-2022#troubleshoot-adding-a-user-to-the-publisher-account).
+  2. Ask a team member who already has access to the publisher to add your user ID to the publisher [here](https://marketplace.visualstudio.com/manage/publishers/tilt-dev).
+3. Set up a Personal Access Token ([docs](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "Tilt",
+    "name": "Tiltfile",
     "displayName": "Tiltfile",
     "description": "Provides an improved editing experience for `Tiltfile` authors.",
     "publisher": "tilt-dev",


### PR DESCRIPTION
apparently I made these changes in my working directory before publishing the initial version but failed to merge them