### PR TITLE
config: add `.tilt` as supported extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
                 ],
                 "extensions": [
                     "Tiltfile",
-                    ".tiltfile"
+                    ".tiltfile",
+                    ".tilt"
                 ],
                 "configuration": "./syntaxes/tiltfile.configuration.json"
             }


### PR DESCRIPTION
One of our partners is using this for their Tilt library files.

While we probably don't want to support every extension under
the sun, this seems reasonable enough, especially since I don't
know of any other software out there using `.tilt` as an extension
for text files.