### PR TITLE
vscode-tilt: clean up logging when no Tilt running

### DIFF
--- a/src/tiltfile-error-watcher.ts
+++ b/src/tiltfile-error-watcher.ts
@@ -70,7 +70,9 @@ export class TiltfileErrorWatcher implements Disposable {
         if (stderr !== "") {
           this.output.append(stderr)
           if (stderr.includes("No tilt apiserver found")) {
-            this.output.appendLine(`No running Tilt found. Tiltfile runtime error highlighting will work when Tilt is started.`)
+            this.output.appendLine(
+              `No running Tilt found. Tiltfile runtime error highlighting will work when Tilt is started.`
+            )
           }
         }
         this.output.appendLine(error)


### PR DESCRIPTION
1. When Tilt isn't running, the extension was logging two lines every five seconds, which made the debug console very annoying to read.
2. Make the output when Tilt isn't running a little more (i.e., at all) meaningful to the user.