### PR TITLE
vscode-tilt: add filter to release test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,11 @@ workflows:
   test-publish:
     jobs:
       - test
+          filters:
+            branches:
+              only: never-release-on-a-branch
+            tags:
+              only: /v[0-9]+.[0-9]+.[0-9]+/
       - vsce/publish:
           context:
             - Tilt VSCE Context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
       - test
   test-publish:
     jobs:
-      - test
+      - test:
           filters:
             branches:
               only: never-release-on-a-branch


### PR DESCRIPTION
circleci is reporting "no workflow". I think that's because the first job in the workflow isn't configured to allow the tag.