### PR TITLE
vscode-tilt: fix icon path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
     "displayName": "Tiltfile",
     "description": "Provides an improved editing experience for `Tiltfile` authors.",
     "publisher": "tilt-dev",
-    "repository": "https://github.com/tilt-dev/vscode-tilt",
-    "icon": "https://raw.githubusercontent.com/tilt-dev/vscode-tilt/main/assets/tilt-transparent.png",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/tilt-dev/vscode-tilt"
+    },
+    "icon": "assets/tilt-transparent.png",
     "preview": true,
     "version": "0.0.3",
     "engines": {


### PR DESCRIPTION
#17 changed the icon value from a path to a url to satisfy the warning "An icon requires a repository with HTTPS protocol to be specified in this package.json.", but then that made publishing fail with "ERROR  The specified icon 'extension/https://raw.githubusercontent.com/tilt-dev/vscode-tilt/main/assets/tilt-transparent.png' wasn't found in the extension."

https://github.com/microsoft/vscode-vsce/issues/341 and https://github.com/microsoft/vscode/issues/30434 make these errors look confusing.

I checked a handful of the top extensions in the vscode marketplace and they all specify their icons as relative paths rather than urls, but they specify their repositories as dicts rather than strings. Changing our repository to a dict and the icon path back to relative made the warning go away 🤷 . I'm guessing the issue is that the vscode warning should have been on the "repository" field for being a string rather than dict.